### PR TITLE
fix: 피드 화면에 너무 꽉차지 않게 맥스 700 설정, 아이패드 프로 1024*1366에서 그리드가 벌어져있는것 수정

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -54,7 +54,7 @@ export default function Feed() {
   return (
     <div className="flex min-h-screen flex-col items-center overflow-y-auto bg-bg-100 bg-cover">
       <FloatingButtons />
-      <div className="mx-[24px] flex min-h-screen w-full max-w-[1200px] flex-col px-[24px] lg:px-[72px]">
+      <div className="mx-[24px] flex w-full max-w-[1200px] flex-col px-[24px] lg:px-[72px]">
         <div className="flex justify-between">
           <h1 className="typo-lg-semibold mb-[24px] mt-[32px] md:typo-xl-semibold xl:typo-2xl-semibold xl:mb-[40px] xl:mt-[120px]">
             피드
@@ -81,7 +81,7 @@ export default function Feed() {
         <div
           className={`grid flex-grow gap-[16px] xl:gap-[30px] ${
             isGrid ? 'grid-cols-2' : 'grid-cols-1'
-          } align-content-start justify-center lg:grid-cols-2`}
+          } items-start justify-start lg:grid-cols-2`}
         >
           {' '}
           {epigrams.map((epigram) => (

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -81,7 +81,7 @@ export default function Feed() {
         <div
           className={`grid flex-grow gap-[16px] xl:gap-[30px] ${
             isGrid ? 'grid-cols-2' : 'grid-cols-1'
-          } justify-center lg:grid-cols-2`}
+          } align-content-start justify-center lg:grid-cols-2`}
         >
           {' '}
           {epigrams.map((epigram) => (

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
-import '../globals.css';
+
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -11,6 +11,7 @@ import FloatingButtons from '@/src/components/epigrams/FloatingButtons';
 
 import { Epigram } from '../../types/epigrams';
 import { getEpigrams } from '../api/epigram';
+import '../globals.css';
 
 export default function Feed() {
   const [epigrams, setEpigrams] = useState<Epigram[]>([]);
@@ -80,12 +81,12 @@ export default function Feed() {
         <div
           className={`grid flex-grow gap-[16px] xl:gap-[30px] ${
             isGrid ? 'grid-cols-2' : 'grid-cols-1'
-          } lg:grid-cols-2`}
+          } justify-center lg:grid-cols-2`}
         >
           {' '}
           {epigrams.map((epigram) => (
             <Link href={`epigrams/${epigram.id}`} key={epigram.id}>
-              <div className="transform transition hover:scale-105 hover:duration-700">
+              <div className="mx-auto max-w-[700px] transform transition hover:scale-105 hover:duration-700">
                 <TextCard
                   id={epigram.id}
                   content={epigram.content}
@@ -100,7 +101,7 @@ export default function Feed() {
           <button
             onClick={handleMore}
             disabled={isLoading}
-            className="typo-md-medium flex h-[48px] w-[180px] justify-center rounded-[100px] border border-[1px] border-line-200 bg-bg-100 px-[18px] py-[12px] text-blue-500 xl:typo-xl-medium hover:text-blue-800 xl:w-[238px] xl:py-[9px]"
+            className="typo-md-medium flex h-[48px] w-[180px] justify-center rounded-[100px] border-[1px] border-line-200 bg-bg-100 px-[18px] py-[12px] text-blue-500 xl:typo-xl-medium hover:text-blue-800 xl:w-[238px] xl:py-[9px]"
           >
             <Image
               src="/assets/ic_plus.svg"


### PR DESCRIPTION
## :bookmark: Issue Ticket

<!-- Issue Ticket이 있을 경우, 해당 링크를 연결해주세요 -->

[Ticket](https://GIRA 페이지 링크)

## :writing_hand: Description

<!-- 어떤 내용의 PR인지 간단하게 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
- 큰 화면에서 줄였을때 너무 피드가 꽉차게 길어보이는부분이 있어서 맥스 700으로 설정하였습니다.
- 아이패드 프로 1024*1366에서 그리드가 벌어져있는것 수정하였습니다.

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인 (필요하면 스크린샷)
수정전
![image](https://github.com/user-attachments/assets/5a0cf17d-f360-48ef-ae84-f426bbd38e41)
수정후
![image](https://github.com/user-attachments/assets/f7dd1e05-45b0-442d-9df0-17162adda2df)


iPad_Pro 1024*1366
수정전
![image](https://github.com/user-attachments/assets/e8229960-11d9-4bae-afa9-87d0fbf13130)
수정후
![image](https://github.com/user-attachments/assets/c44c000f-08e0-4e27-95ed-904fcdc34a91)


### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
